### PR TITLE
Eng 1774/update tsconfig package json settings

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,6 @@
 .prettierrc
 test/
 yarn-error.log
+typedoc.*
+tsconfig.json
+.prettierignore

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Custom HTTP Errors",
   "exports": {
     ".": {
-      "types": "./types/http-errors/index.d.js",
+      "types": "./types/http-errors/index.d.ts",
       "default": "./src/http-errors/index.js"
     },
     "./middleware": {
-      "types": "./types/middleware/index.d.js",
+      "types": "./types/middleware/index.d.ts",
       "default": "./src/middleware/index.js"
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["es2021"],
+    "lib": ["ES2021"],
     "moduleResolution": "node16", // for Node.js' CommonJS implementation
-    "module": "CommonJS", // CommonJS for node projects
+    "module": "commonjs", // CommonJS for node projects
     "allowSyntheticDefaultImports": true, // allows to write an import like import <module> from "<package>"
     "allowJs": true, // allow .js files instead of just .ts and .tsx
     "checkJs": true, // works in tandem with allowJS - allows errors to be reported in .js files
@@ -11,8 +11,7 @@
     "declarationMap": true,
     "strict": true, //  equivalent to enabling all strict mode family options - stronger type checking
     "alwaysStrict": true, // ensures files are parsed in ECMASCript strict mode, and emit "use strict" for each source file.
-    "declarationDir": "./types", // configure root directory for declaration files
-    "target": "es2021"
+    "declarationDir": "./types" // configure root directory for declaration files
   },
   "include": ["./src/http-errors/index.js", "./src/middleware/index.js"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
- [Use TS docs recommendation for tsconfig](https://github.com/abs-warranty/http-errors/commit/dfa45438c5e9e11668f84b687b3efe240c516a8f)
- [Use index.d.ts for types resolution](https://github.com/abs-warranty/http-errors/commit/37c7a1c9197e1cf8b1bfeab77e194d5d1680bd31)
- [Add typedoc tsconfig and prettier to npmignore](https://github.com/abs-warranty/http-errors/commit/c7203d7ee30c9d6424945193a580ded00b945d16)